### PR TITLE
Make it linkable to C++

### DIFF
--- a/src/uuid4.h
+++ b/src/uuid4.h
@@ -8,6 +8,10 @@
 #ifndef UUID4_H
 #define UUID4_H
 
+#ifdef __cplusplus
+  extern "C" {
+#endif //__cplusplus
+    
 #define UUID4_VERSION "1.0.0"
 #define UUID4_LEN 37
 
@@ -18,5 +22,9 @@ enum {
 
 int  uuid4_init(void);
 void uuid4_generate(char *dst);
+
+#ifdef __cplusplus
+  }
+#endif //__cplusplus
 
 #endif


### PR DESCRIPTION
Add __cplusplus definition to make it linkable to C++ when link it as a library.