### PR TITLE
Add support for openbsd and netbsd

### DIFF
--- a/src/uuid4.c
+++ b/src/uuid4.c
@@ -31,7 +31,7 @@ static uint64_t xorshift128plus(uint64_t *s) {
 
 
 int uuid4_init(void) {
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
   int res;
   FILE *fp = fopen("/dev/urandom", "rb");
   if (!fp) {


### PR DESCRIPTION
Both OpenBSD and NetBSD have a [urandom](https://man.openbsd.org/urandom.4) file, currently uuid4 doesn't has these *BSD macros, this PR adds them.