### PR TITLE
Switch to xoroshiro128plus

### DIFF
--- a/src/uuid4.c
+++ b/src/uuid4.c
@@ -19,14 +19,20 @@
 static uint64_t seed[2];
 
 
-static uint64_t xorshift128plus(uint64_t *s) {
-  /* http://xorshift.di.unimi.it/xorshift128plus.c */
-  uint64_t s1 = s[0];
-  const uint64_t s0 = s[1];
-  s[0] = s0;
-  s1 ^= s1 << 23;
-  s[1] = s1 ^ s0 ^ (s1 >> 18) ^ (s0 >> 5);
-  return s[1] + s0;
+static inline uint64_t rotl(const uint64_t x, int k) {
+  return (x << k) | (x >> (64 - k));
+}
+
+
+static uint64_t xoroshiro128plus(uint64_t *s) {
+  /* https://prng.di.unimi.it/xoroshiro128plus.c */
+  const uint64_t s0 = s[0];
+  uint64_t s1 = s[1];
+  const uint64_t result = s0 + s1;
+  s1 ^= s0;
+  s[0] = rotl(s0, 24) ^ s1 ^ (s1 << 16); // a, b
+  s[1] = rotl(s1, 37); // c
+  return result;
 }
 
 
@@ -71,8 +77,8 @@ void uuid4_generate(char *dst) {
   const char *p;
   int i, n;
   /* get random */
-  s.word[0] = xorshift128plus(seed);
-  s.word[1] = xorshift128plus(seed);
+  s.word[0] = xoroshiro128plus(seed);
+  s.word[1] = xoroshiro128plus(seed);
   /* build string */
   p = template;
   i = 0;


### PR DESCRIPTION
The authors of the previously-used `xorshift128+` implementation suggest, in the reference source, to move to `xoroshiro128+`. The comments in that implementation mention some caveats about the fidelity of the lower bits and outputs beyond 5TB. So out of an absolute overabundance of caution one could switch to `xoroshiro128++` instead of `xoroshiro128+`, which is slightly slower.

However it seems that this would not justify the slight increase in runtime. With a modified example.c running a _large_ number of iterations before printing, `xoroshiro128++` seems slightly slower, while `xoroshiro128+` and `xorshift128+` are about the same speed (accuracy is ~0.5sec in each case):

```shell
$ ./build.sh && time ./example # xorshift128+
Generated 100000000 iterations. Last UUID: a078c6b1-bd15-4018-8015-59ef66925a55
./example 11.33s user 0.00s system 99% cpu 11.372 total

$ ./build.sh && time ./example # xoroshiro128+
Generated 100000000 iterations. Last UUID: 0ab70d5e-0156-4830-a663-2e4fef1a45d6
./example 11.58s user 0.00s system 99% cpu 11.631 total

$ ./build.sh && time ./example # xoroshiro128++
Generated 100000000 iterations. Last UUID: 450d0a68-143b-45db-9d72-5c12125277c7
./example 12.45s user 0.00s system 99% cpu 12.499 total
```
